### PR TITLE
Upgrade 5.10.x kernel & buildroot to 2022.02.3

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -2,7 +2,7 @@ FROM ubuntu
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
-    apt-get install -y build-essential wget libncurses5-dev unzip bc curl python rsync ccache vim less cpio texinfo locales git
+    apt-get install -y build-essential wget libncurses5-dev unzip bc curl python3 file rsync ccache vim less cpio texinfo locales git
 
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -13,7 +13,7 @@ ENV SHELL /bin/bash
 ENV ARTIFACTS /usr/src
 WORKDIR ${DAPPER_SOURCE}
 
-ENV VERSION 2021.02.2
+ENV VERSION 2022.02.3
 ENV TARBALL ${VERSION}.tar.gz
 RUN cd ${ARTIFACTS} && \
     wget https://github.com/buildroot/buildroot/archive/$TARBALL

--- a/config/amd64/buildroot-config
+++ b/config/amd64/buildroot-config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Buildroot 2021.02.2 Configuration
+# Buildroot 2022.02 Configuration
 #
 BR2_HAVE_DOT_CONFIG=y
 BR2_HOST_GCC_AT_LEAST_4_9=y
@@ -45,6 +45,7 @@ BR2_x86_64=y
 # BR2_xtensa is not set
 BR2_ARCH_HAS_TOOLCHAIN_BUILDROOT=y
 BR2_ARCH="x86_64"
+BR2_NORMALIZED_ARCH="x86_64"
 BR2_ENDIAN="LITTLE"
 BR2_GCC_TARGET_ARCH="nocona"
 BR2_BINFMT_SUPPORTS_SHARED=y
@@ -54,14 +55,37 @@ BR2_X86_CPU_HAS_MMX=y
 BR2_X86_CPU_HAS_SSE=y
 BR2_X86_CPU_HAS_SSE2=y
 BR2_X86_CPU_HAS_SSE3=y
+# BR2_x86_x86_64 is not set
+# BR2_x86_x86_64_v2 is not set
+# BR2_x86_x86_64_v3 is not set
+# BR2_x86_x86_64_v4 is not set
 BR2_x86_nocona=y
 # BR2_x86_core2 is not set
 # BR2_x86_corei7 is not set
+# BR2_x86_nehalem is not set
 # BR2_x86_westmere is not set
 # BR2_x86_corei7_avx is not set
+# BR2_x86_sandybridge is not set
 # BR2_x86_core_avx2 is not set
+# BR2_x86_haswell is not set
+# BR2_x86_broadwell is not set
+# BR2_x86_skylake is not set
 # BR2_x86_atom is not set
+# BR2_x86_bonnel is not set
 # BR2_x86_silvermont is not set
+# BR2_x86_goldmont is not set
+# BR2_x86_goldmont_plus is not set
+# BR2_x86_tremont is not set
+# BR2_x86_skylake_avx512 is not set
+# BR2_x86_cannonlake is not set
+# BR2_x86_icelake_client is not set
+# BR2_x86_icelake_server is not set
+# BR2_x86_cascadelake is not set
+# BR2_x86_cooperlake is not set
+# BR2_x86_tigerlake is not set
+# BR2_x86_sapphirerapids is not set
+# BR2_x86_alderlake is not set
+# BR2_x86_rocketlake is not set
 # BR2_x86_opteron is not set
 # BR2_x86_opteron_sse3 is not set
 # BR2_x86_barcelona is not set
@@ -82,6 +106,7 @@ BR2_GIT="git"
 BR2_CVS="cvs"
 BR2_LOCALFILES="cp"
 BR2_SCP="scp"
+BR2_SFTP="sftp"
 BR2_HG="hg"
 BR2_ZCAT="gzip -d -c"
 BR2_BZCAT="bzcat"
@@ -104,6 +129,7 @@ BR2_CPAN_MIRROR="http://cpan.metacpan.org"
 BR2_JLEVEL=0
 # BR2_CCACHE is not set
 # BR2_ENABLE_DEBUG is not set
+# BR2_ENABLE_RUNTIME_DEBUG is not set
 BR2_STRIP_strip=y
 BR2_STRIP_EXCLUDE_FILES=""
 BR2_STRIP_EXCLUDE_DIRS=""
@@ -131,6 +157,7 @@ BR2_REPRODUCIBLE=y
 #
 # Security Hardening Options
 #
+BR2_PIC_PIE_ARCH_SUPPORTS=y
 # BR2_PIC_PIE is not set
 # BR2_SSP_NONE is not set
 # BR2_SSP_REGULAR is not set
@@ -140,6 +167,7 @@ BR2_SSP_OPTION="-fstack-protector-all"
 BR2_RELRO_NONE=y
 # BR2_RELRO_PARTIAL is not set
 # BR2_RELRO_FULL is not set
+BR2_FORTIFY_SOURCE_ARCH_SUPPORTS=y
 BR2_FORTIFY_SOURCE_NONE=y
 # BR2_FORTIFY_SOURCE_1 is not set
 # BR2_FORTIFY_SOURCE_2 is not set
@@ -166,40 +194,42 @@ BR2_TOOLCHAIN_BUILDROOT_LIBC="glibc"
 #
 # BR2_KERNEL_HEADERS_4_4 is not set
 # BR2_KERNEL_HEADERS_4_9 is not set
-# BR2_KERNEL_HEADERS_4_14 is not set
+BR2_KERNEL_HEADERS_4_14=y
 # BR2_KERNEL_HEADERS_4_19 is not set
 # BR2_KERNEL_HEADERS_5_4 is not set
-BR2_KERNEL_HEADERS_5_10=y
+# BR2_KERNEL_HEADERS_5_10 is not set
+# BR2_KERNEL_HEADERS_5_15 is not set
+# BR2_KERNEL_HEADERS_5_16 is not set
 # BR2_KERNEL_HEADERS_VERSION is not set
 # BR2_KERNEL_HEADERS_CUSTOM_TARBALL is not set
 # BR2_KERNEL_HEADERS_CUSTOM_GIT is not set
-BR2_KERNEL_HEADERS_LATEST=y
-BR2_DEFAULT_KERNEL_HEADERS="5.10.35"
+BR2_DEFAULT_KERNEL_HEADERS="5.10.129"
 BR2_PACKAGE_LINUX_HEADERS=y
 
 #
 # Glibc Options
 #
 BR2_PACKAGE_GLIBC=y
+# BR2_PACKAGE_GLIBC_KERNEL_COMPAT is not set
 # BR2_PACKAGE_GLIBC_UTILS is not set
 
 #
 # Binutils Options
 #
 BR2_PACKAGE_HOST_BINUTILS_SUPPORTS_CFI=y
-# BR2_BINUTILS_VERSION_2_32_X is not set
-# BR2_BINUTILS_VERSION_2_34_X is not set
+BR2_BINUTILS_VERSION_2_32_X=y
 # BR2_BINUTILS_VERSION_2_35_X is not set
-BR2_BINUTILS_VERSION_2_36_X=y
-BR2_BINUTILS_VERSION="2.36.1"
+# BR2_BINUTILS_VERSION_2_36_X is not set
+# BR2_BINUTILS_VERSION_2_37_X is not set
+BR2_BINUTILS_VERSION="2.32"
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS=""
 
 #
 # GCC Options
 #
-# BR2_GCC_VERSION_8_X is not set
 # BR2_GCC_VERSION_9_X is not set
 BR2_GCC_VERSION_10_X=y
+# BR2_GCC_VERSION_11_X is not set
 BR2_GCC_SUPPORTS_DLANG=y
 BR2_GCC_VERSION="10.3.0"
 BR2_EXTRA_GCC_CONFIG_OPTIONS=""
@@ -272,25 +302,7 @@ BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_11=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_12=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_13=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_14=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_15=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_16=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_17=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_18=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_19=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_20=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_0=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_1=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_2=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_3=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_4=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_5=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_6=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_7=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_8=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_9=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_10=y
-BR2_TOOLCHAIN_HEADERS_LATEST=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST="5.10"
+BR2_TOOLCHAIN_HEADERS_AT_LEAST="4.14"
 BR2_TOOLCHAIN_GCC_AT_LEAST_4_3=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_4_4=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_4_5=y
@@ -356,6 +368,7 @@ BR2_GENERATE_LOCALE=""
 # BR2_TARGET_TZ_INFO is not set
 BR2_ROOTFS_USERS_TABLES=""
 BR2_ROOTFS_OVERLAY=""
+BR2_ROOTFS_PRE_BUILD_SCRIPT=""
 BR2_ROOTFS_POST_BUILD_SCRIPT="../../scripts/fix-up-image.sh"
 BR2_ROOTFS_POST_FAKEROOT_SCRIPT=""
 BR2_ROOTFS_POST_IMAGE_SCRIPT=""
@@ -415,11 +428,11 @@ BR2_PACKAGE_FFMPEG_ARCH_SUPPORTS=y
 BR2_PACKAGE_KODI_ARCH_SUPPORTS=y
 
 #
-# kodi needs python w/ .py modules, a uClibc or glibc toolchain w/ C++, threads, wchar, dynamic library, gcc >= 4.8
+# kodi needs python3 w/ .py modules, a uClibc or glibc toolchain w/ C++, threads, wchar, dynamic library, gcc >= 4.9
 #
 
 #
-# kodi needs an OpenGL EGL backend with OpenGL support
+# kodi needs an OpenGL EGL backend with OpenGL or GLES support
 #
 # BR2_PACKAGE_LAME is not set
 # BR2_PACKAGE_MADPLAY is not set
@@ -441,7 +454,7 @@ BR2_PACKAGE_MJPEGTOOLS_SIMD_SUPPORT=y
 # BR2_PACKAGE_MOTION is not set
 
 #
-# mpd needs a toolchain w/ C++, threads, wchar, gcc >= 7, host gcc >= 7
+# mpd needs a toolchain w/ C++, threads, wchar, gcc >= 8, host gcc >= 8
 #
 # BR2_PACKAGE_MPD_MPC is not set
 # BR2_PACKAGE_MPG123 is not set
@@ -489,6 +502,10 @@ BR2_PACKAGE_PULSEAUDIO_HAS_ATOMIC=y
 # BR2_PACKAGE_YMPD is not set
 
 #
+# zynaddsubfx needs a toolchain w/ C++11 and threads
+#
+
+#
 # Compressors and decompressors
 #
 # BR2_PACKAGE_BROTLI is not set
@@ -527,6 +544,7 @@ BR2_PACKAGE_XZ=y
 #
 # bonnie++ needs a toolchain w/ C++
 #
+# BR2_PACKAGE_BPFTOOL is not set
 # BR2_PACKAGE_CACHE_CALIBRATOR is not set
 
 #
@@ -572,6 +590,8 @@ BR2_PACKAGE_KEXEC_ZLIB=y
 BR2_PACKAGE_KVM_UNIT_TESTS_ARCH_SUPPORTS=y
 # BR2_PACKAGE_KVM_UNIT_TESTS is not set
 # BR2_PACKAGE_LATENCYTOP is not set
+BR2_PACKAGE_LIBBPF_ARCH_SUPPORTS=y
+# BR2_PACKAGE_LIBBPF is not set
 # BR2_PACKAGE_LMBENCH is not set
 # BR2_PACKAGE_LSOF is not set
 BR2_PACKAGE_LTP_TESTSUITE_ARCH_SUPPORTS=y
@@ -601,6 +621,7 @@ BR2_PACKAGE_OPROFILE_ARCH_SUPPORTS=y
 #
 BR2_PACKAGE_PLY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_PLY is not set
+# BR2_PACKAGE_POKE is not set
 # BR2_PACKAGE_PV is not set
 
 #
@@ -613,6 +634,10 @@ BR2_PACKAGE_PLY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_RAMSMP is not set
 # BR2_PACKAGE_RAMSPEED is not set
 # BR2_PACKAGE_RT_TESTS is not set
+
+#
+# rwmem needs a toolchain w/ C++, wchar, gcc >= 5
+#
 
 #
 # sentry-native needs a glibc toolchain with w/ wchar, thread, C++, gcc >= 4.8
@@ -634,6 +659,8 @@ BR2_PACKAGE_TCF_AGENT_ARCH_SUPPORTS=y
 BR2_PACKAGE_TRINITY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_TRINITY is not set
 # BR2_PACKAGE_UCLIBC_NG_TEST is not set
+BR2_PACKAGE_UFTRACE_ARCH_SUPPORTS=y
+# BR2_PACKAGE_UFTRACE is not set
 BR2_PACKAGE_VALGRIND_ARCH_SUPPORTS=y
 # BR2_PACKAGE_VALGRIND is not set
 # BR2_PACKAGE_VMTOUCH is not set
@@ -684,6 +711,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 BR2_PACKAGE_JQ=y
 # BR2_PACKAGE_LIBTOOL is not set
 # BR2_PACKAGE_MAKE is not set
+# BR2_PACKAGE_MAWK is not set
 # BR2_PACKAGE_PATCH is not set
 # BR2_PACKAGE_PKGCONF is not set
 # BR2_PACKAGE_RIPGREP is not set
@@ -711,6 +739,10 @@ BR2_PACKAGE_JQ=y
 BR2_PACKAGE_E2FSPROGS=y
 # BR2_PACKAGE_E2FSPROGS_DEBUGFS is not set
 # BR2_PACKAGE_E2FSPROGS_E2IMAGE is not set
+
+#
+# e2scrub needs bash, coreutils, lvm2, and util-linux
+#
 # BR2_PACKAGE_E2FSPROGS_E4DEFRAG is not set
 BR2_PACKAGE_E2FSPROGS_FSCK=y
 # BR2_PACKAGE_E2FSPROGS_FUSE2FS is not set
@@ -722,6 +754,7 @@ BR2_PACKAGE_E2FSPROGS_RESIZE2FS=y
 # BR2_PACKAGE_EXFAT_UTILS is not set
 # BR2_PACKAGE_EXFATPROGS is not set
 # BR2_PACKAGE_F2FS_TOOLS is not set
+# BR2_PACKAGE_FIRMWARE_UTILS is not set
 # BR2_PACKAGE_FLASHBENCH is not set
 # BR2_PACKAGE_FSCRYPTCTL is not set
 # BR2_PACKAGE_FUSE_OVERLAYFS is not set
@@ -729,6 +762,7 @@ BR2_PACKAGE_E2FSPROGS_RESIZE2FS=y
 # BR2_PACKAGE_GENEXT2FS is not set
 # BR2_PACKAGE_GENPART is not set
 # BR2_PACKAGE_GENROMFS is not set
+# BR2_PACKAGE_GOCRYPTFS is not set
 # BR2_PACKAGE_IMX_USB_LOADER is not set
 # BR2_PACKAGE_MMC_UTILS is not set
 # BR2_PACKAGE_MTD is not set
@@ -742,6 +776,10 @@ BR2_PACKAGE_E2FSPROGS_RESIZE2FS=y
 # BR2_PACKAGE_UDFTOOLS is not set
 # BR2_PACKAGE_UNIONFS is not set
 BR2_PACKAGE_XFSPROGS=y
+
+#
+# zfs needs a Linux kernel to be built
+#
 
 #
 # Fonts, cursors, icons, sounds and themes
@@ -810,7 +848,7 @@ BR2_PACKAGE_XFSPROGS=y
 #
 
 #
-# stella needs a toolchain w/ dynamic library, C++, threads, gcc >= 6
+# stella needs a toolchain w/ dynamic library, C++, threads, gcc >= 7
 #
 # BR2_PACKAGE_XORCURSES is not set
 
@@ -823,7 +861,7 @@ BR2_PACKAGE_XFSPROGS=y
 #
 
 #
-# cage needs udev, mesa3d w/ EGL and GLES support
+# cage needs udev, EGL w/ Wayland backend and OpenGL ES support
 #
 
 #
@@ -843,7 +881,20 @@ BR2_PACKAGE_XFSPROGS=y
 # BR2_PACKAGE_JHEAD is not set
 
 #
+# kmscube needs EGL, GBM and OpenGL ES, and a toolchain w/ thread support
+#
+
+#
 # libva-utils needs a toolchain w/ C++, threads, dynamic library
+#
+BR2_PACKAGE_MIDORI_ARCH_SUPPORTS=y
+
+#
+# midori needs a glibc toolchain w/ C++, wchar, threads, dynamic library, gcc >= 7, host gcc >= 8
+#
+
+#
+# midori needs libgtk3 w/ X11 or wayland backend
 #
 BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_NETSURF is not set
@@ -855,15 +906,16 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 #
 
 #
-# tesseract-ocr needs a toolchain w/ threads, C++, gcc >= 4.8, dynamic library, wchar
+# tesseract-ocr needs a toolchain w/ threads, C++, gcc >= 7, dynamic library, wchar
 #
+# BR2_PACKAGE_TINIFIER is not set
 
 #
 # Graphic libraries
 #
 
 #
-# cegui needs a toolchain w/ C++, threads, dynamic library, wchar
+# cegui needs a toolchain w/ C++, threads, dynamic library, wchar, gcc >= 5
 #
 
 #
@@ -888,6 +940,7 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_GRAPHICSMAGICK is not set
 # BR2_PACKAGE_IMAGEMAGICK is not set
+# BR2_PACKAGE_LIBGLVND is not set
 
 #
 # linux-fusion needs a Linux kernel to be built
@@ -907,6 +960,7 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_PSPLASH is not set
 # BR2_PACKAGE_SDL is not set
 # BR2_PACKAGE_SDL2 is not set
+# BR2_PACKAGE_VULKAN_HEADERS is not set
 
 #
 # Other GUIs
@@ -924,15 +978,15 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 # BR2_PACKAGE_XORG7 is not set
 
 #
-# apitrace needs a toolchain w/ C++, wchar, dynamic library, threads, gcc >= 4.9
+# apitrace needs a toolchain w/ C++, wchar, dynamic library, threads, gcc >= 7
 #
 
 #
-# midori needs libgtk3 and a glibc toolchain w/ C++, gcc >= 7, host gcc >= 4.9
+# mupdf needs a toolchain w/ C++, gcc >= 4.9
 #
 
 #
-# vte needs a toolchain w/ wchar, threads, C++, gcc >= 4.8
+# vte needs a uClibc or glibc toolchain w/ wchar, threads, C++, gcc >= 10
 #
 
 #
@@ -992,10 +1046,18 @@ BR2_PACKAGE_CRYPTSETUP=y
 # dahdi-tools needs a toolchain w/ threads and a Linux kernel to be built
 #
 # BR2_PACKAGE_DBUS is not set
+
+#
+# dbus-cxx needs a toolchain w/ C++, threads, gcc >= 7 and dynamic library support
+#
 # BR2_PACKAGE_DFU_UTIL is not set
 # BR2_PACKAGE_DMIDECODE is not set
 # BR2_PACKAGE_DMRAID is not set
 # BR2_PACKAGE_DT_UTILS is not set
+
+#
+# dtbocfg needs a Linux kernel to be built
+#
 # BR2_PACKAGE_DTV_SCAN_TABLES is not set
 # BR2_PACKAGE_DUMP1090 is not set
 # BR2_PACKAGE_DVB_APPS is not set
@@ -1011,6 +1073,7 @@ BR2_PACKAGE_EUDEV_ENABLE_HWDB=y
 BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_FLASHROM is not set
 # BR2_PACKAGE_FMTOOLS is not set
+# BR2_PACKAGE_FREEIPMI is not set
 # BR2_PACKAGE_FXLOAD is not set
 # BR2_PACKAGE_GPM is not set
 # BR2_PACKAGE_GPSD is not set
@@ -1026,7 +1089,6 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_I7Z is not set
 # BR2_PACKAGE_INPUT_EVENT_DAEMON is not set
 # BR2_PACKAGE_INTEL_MICROCODE is not set
-# BR2_PACKAGE_IOSTAT is not set
 # BR2_PACKAGE_IPMITOOL is not set
 # BR2_PACKAGE_IPMIUTIL is not set
 # BR2_PACKAGE_IRDA_UTILS is not set
@@ -1059,8 +1121,10 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LUKSMETA is not set
 BR2_PACKAGE_LVM2=y
 BR2_PACKAGE_LVM2_STANDARD_INSTALL=y
-# BR2_PACKAGE_LVM2_APP_LIBRARY is not set
-# BR2_PACKAGE_LVM2_LVMETAD is not set
+
+#
+# mali-driver needs a Linux kernel to be built
+#
 # BR2_PACKAGE_MBPFAN is not set
 BR2_PACKAGE_MDADM=y
 # BR2_PACKAGE_MDEVD is not set
@@ -1095,6 +1159,7 @@ BR2_PACKAGE_PARTED=y
 # powertop needs a toolchain w/ C++, threads, wchar
 #
 # BR2_PACKAGE_PPS_TOOLS is not set
+# BR2_PACKAGE_QORIQ_CADENCE_DP_FIRMWARE is not set
 # BR2_PACKAGE_RASPI_GPIO is not set
 # BR2_PACKAGE_READ_EDID is not set
 BR2_PACKAGE_RNG_TOOLS=y
@@ -1108,6 +1173,10 @@ BR2_PACKAGE_RNG_TOOLS_JITTERENTROPY_LIBRARY=y
 #
 
 #
+# rtl8189es needs a Linux kernel to be built
+#
+
+#
 # rtl8189fs needs a Linux kernel to be built
 #
 
@@ -1117,6 +1186,10 @@ BR2_PACKAGE_RNG_TOOLS_JITTERENTROPY_LIBRARY=y
 
 #
 # rtl8723bu needs a Linux kernel to be built
+#
+
+#
+# rtl8812au-aircrack-ng needs a Linux kernel to be built
 #
 
 #
@@ -1147,10 +1220,6 @@ BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
 #
 # targetcli-fb depends on Python
 #
-
-#
-# ti-sgx-um needs the ti-sgx-km driver
-#
 # BR2_PACKAGE_TI_UIM is not set
 # BR2_PACKAGE_TI_UTILS is not set
 # BR2_PACKAGE_TIO is not set
@@ -1162,15 +1231,16 @@ BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
 # uccp420wlan needs a Linux kernel >= 4.2 to be built
 #
 BR2_PACKAGE_HAS_UDEV=y
-
-#
-# udisks needs a glibc or musl toolchain with locale, C++, wchar, dynamic library, NPTL, gcc >= 4.9
-#
+# BR2_PACKAGE_UDISKS is not set
 # BR2_PACKAGE_UHUBCTL is not set
 # BR2_PACKAGE_UMTPRD is not set
 # BR2_PACKAGE_UPOWER is not set
 # BR2_PACKAGE_USB_MODESWITCH is not set
 # BR2_PACKAGE_USB_MODESWITCH_DATA is not set
+
+#
+# usbguard needs a glibc or uClibc toolchain w/ C++, threads, dynamic library, gcc >= 4.8
+#
 # BR2_PACKAGE_USBMOUNT is not set
 # BR2_PACKAGE_USBUTILS is not set
 # BR2_PACKAGE_W_SCAN is not set
@@ -1195,6 +1265,7 @@ BR2_PACKAGE_GAUCHE_ARCH_SUPPORTS=y
 # BR2_PACKAGE_GAUCHE is not set
 # BR2_PACKAGE_GUILE is not set
 # BR2_PACKAGE_HASERL is not set
+# BR2_PACKAGE_JANET is not set
 # BR2_PACKAGE_JIMTCL is not set
 # BR2_PACKAGE_LUA is not set
 BR2_PACKAGE_PROVIDES_HOST_LUAINTERPRETER="host-lua"
@@ -1211,7 +1282,7 @@ BR2_PACKAGE_MONO_ARCH_SUPPORTS=y
 BR2_PACKAGE_NODEJS_ARCH_SUPPORTS=y
 
 #
-# nodejs needs a toolchain w/ C++, dynamic library, NPTL, gcc >= 4.9, wchar
+# nodejs needs a toolchain w/ C++, dynamic library, NPTL, gcc >= 7, wchar, host gcc >= 8
 #
 BR2_PACKAGE_HOST_OPENJDK_BIN_ARCH_SUPPORTS=y
 BR2_PACKAGE_OPENJDK_ARCH_SUPPORTS=y
@@ -1221,11 +1292,10 @@ BR2_PACKAGE_OPENJDK_ARCH_SUPPORTS=y
 #
 
 #
-# openjdk needs glibc, and a toolchain w/ wchar, dynamic library, threads, C++, gcc >= 4.9
+# openjdk needs glibc, and a toolchain w/ wchar, dynamic library, threads, C++, gcc >= 4.9, host gcc >= 4.9
 #
 # BR2_PACKAGE_PERL is not set
 # BR2_PACKAGE_PHP is not set
-# BR2_PACKAGE_PYTHON is not set
 # BR2_PACKAGE_PYTHON3 is not set
 # BR2_PACKAGE_QUICKJS is not set
 # BR2_PACKAGE_RUBY is not set
@@ -1294,9 +1364,11 @@ BR2_PACKAGE_FDK_AAC_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBSOXR is not set
 # BR2_PACKAGE_LIBVORBIS is not set
+# BR2_PACKAGE_LILV is not set
+# BR2_PACKAGE_LV2 is not set
 
 #
-# mp4v2 needs a toolchain w/ C++
+# mp4v2 needs a toolchain w/ C++, gcc >= 5
 #
 BR2_PACKAGE_OPENAL_ARCH_SUPPORTS=y
 
@@ -1314,6 +1386,7 @@ BR2_PACKAGE_OPENAL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_SPANDSP is not set
 # BR2_PACKAGE_SPEEX is not set
 # BR2_PACKAGE_SPEEXDSP is not set
+# BR2_PACKAGE_SRATOM is not set
 
 #
 # taglib needs a toolchain w/ C++, wchar
@@ -1345,6 +1418,7 @@ BR2_PACKAGE_WEBRTC_AUDIO_PROCESSING_ARCH_SUPPORTS=y
 # snappy needs a toolchain w/ C++
 #
 # BR2_PACKAGE_SZIP is not set
+# BR2_PACKAGE_ZCHUNK is not set
 BR2_PACKAGE_ZLIB_NG_ARCH_SUPPORTS=y
 BR2_PACKAGE_ZLIB=y
 BR2_PACKAGE_LIBZLIB=y
@@ -1369,6 +1443,10 @@ BR2_PACKAGE_BOTAN_ARCH_SUPPORTS=y
 #
 # cryptodev needs a Linux kernel to be built
 #
+
+#
+# cryptopp needs a toolchain w/ C++, dynamic library, wchar
+#
 # BR2_PACKAGE_GCR is not set
 # BR2_PACKAGE_GNUTLS is not set
 BR2_PACKAGE_LIBARGON2=y
@@ -1380,7 +1458,7 @@ BR2_PACKAGE_LIBGPG_ERROR_SYSCFG="x86_64-unknown-linux-gnu"
 # BR2_PACKAGE_LIBGPGME is not set
 # BR2_PACKAGE_LIBKCAPI is not set
 # BR2_PACKAGE_LIBKSBA is not set
-# BR2_PACKAGE_LIBMCRYPT is not set
+# BR2_PACKAGE_LIBMD is not set
 # BR2_PACKAGE_LIBMHASH is not set
 # BR2_PACKAGE_LIBNSS is not set
 
@@ -1396,14 +1474,37 @@ BR2_PACKAGE_LIBGPG_ERROR_SYSCFG="x86_64-unknown-linux-gnu"
 # BR2_PACKAGE_LIBSSH2 is not set
 # BR2_PACKAGE_LIBTOMCRYPT is not set
 # BR2_PACKAGE_LIBUECC is not set
+# BR2_PACKAGE_LIBXCRYPT is not set
 # BR2_PACKAGE_MBEDTLS is not set
 # BR2_PACKAGE_NETTLE is not set
-BR2_PACKAGE_LIBOPENSSL_ARCH_SUPPORTS=y
 BR2_PACKAGE_OPENSSL=y
 BR2_PACKAGE_LIBOPENSSL=y
 BR2_PACKAGE_LIBOPENSSL_TARGET_ARCH="linux-x86_64"
 # BR2_PACKAGE_LIBOPENSSL_BIN is not set
 # BR2_PACKAGE_LIBOPENSSL_ENGINES is not set
+BR2_PACKAGE_LIBOPENSSL_ENABLE_CHACHA=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_RC5=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_RC2=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_RC4=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_MD2=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_MD4=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_MDC2=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_BLAKE2=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_IDEA=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_SEED=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_DES=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_RMD160=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_WHIRLPOOL=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_BLOWFISH=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_SSL=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_SSL2=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_SSL3=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_WEAK_SSL=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_PSK=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_CAST=y
+BR2_PACKAGE_LIBOPENSSL_UNSECURE=y
+BR2_PACKAGE_LIBOPENSSL_DYNAMIC_ENGINE=y
+BR2_PACKAGE_LIBOPENSSL_ENABLE_COMP=y
 # BR2_PACKAGE_LIBRESSL is not set
 BR2_PACKAGE_HAS_OPENSSL=y
 BR2_PACKAGE_PROVIDES_OPENSSL="libopenssl"
@@ -1431,6 +1532,8 @@ BR2_PACKAGE_PROVIDES_HOST_OPENSSL="host-libopenssl"
 #
 # leveldb needs a toolchain w/ C++, threads, gcc >= 4.8
 #
+# BR2_PACKAGE_LIBDBI is not set
+# BR2_PACKAGE_LIBDBI_DRIVERS is not set
 # BR2_PACKAGE_LIBGIT2 is not set
 # BR2_PACKAGE_LIBMDBX is not set
 
@@ -1448,6 +1551,7 @@ BR2_PACKAGE_MONGODB_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_POSTGRESQL is not set
 # BR2_PACKAGE_REDIS is not set
+BR2_PACKAGE_ROCKSDB_ARCH_SUPPORTS=y
 
 #
 # rocksdb needs a toolchain w/ C++, threads, wchar, gcc >= 4.8
@@ -1491,16 +1595,16 @@ BR2_PACKAGE_LIBSYSFS=y
 # BR2_PACKAGE_ATK is not set
 
 #
-# atkmm needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# atkmm needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 
 #
-# bullet needs a toolchain w/ C++
+# bullet needs a toolchain w/ C++, dynamic library, threads, wchar
 #
 # BR2_PACKAGE_CAIRO is not set
 
 #
-# cairomm needs a toolchain w/ C++, wchar, threads, gcc >= 4.8
+# cairomm needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 
 #
@@ -1529,26 +1633,18 @@ BR2_PACKAGE_LIBSYSFS=y
 #
 
 #
-# gtkmm3 needs libgtk3 and a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# gtkmm3 needs libgtk3 and a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 
 #
-# harfbuzz needs a toolchain w/ C++, gcc >= 4.8
+# harfbuzz needs a toolchain w/ C++, gcc >= 4.9
 #
 # BR2_PACKAGE_IJS is not set
 # BR2_PACKAGE_IMLIB2 is not set
 # BR2_PACKAGE_INTEL_GMMLIB is not set
 
 #
-# intel-mediadriver needs X.org
-#
-
-#
 # intel-mediadriver needs a toolchain w/ dynamic library, C++, NPTL
-#
-
-#
-# intel-mediasdk needs X.org
 #
 
 #
@@ -1582,7 +1678,7 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 # BR2_PACKAGE_LIBEXIF is not set
 
 #
-# libfm needs X.org and a toolchain w/ wchar, threads, C++, gcc >= 4.8
+# libfm needs X.org and a toolchain w/ wchar, threads, C++, gcc >= 4.9
 #
 # BR2_PACKAGE_LIBFM_EXTRA is not set
 
@@ -1603,7 +1699,7 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 #
 
 #
-# libglfw depends on X.org and needs an OpenGL backend
+# libglfw depends on X.org or Wayland and an OpenGL or GLES backend
 #
 
 #
@@ -1612,7 +1708,7 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 # BR2_PACKAGE_LIBGTA is not set
 
 #
-# libgtk3 needs a toolchain w/ wchar, threads, C++, gcc >= 4.8
+# libgtk3 needs a toolchain w/ wchar, threads, C++, gcc >= 4.9
 #
 
 #
@@ -1628,11 +1724,7 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 #
 
 #
-# librsvg needs a toolchain w/ wchar, threads, C++, gcc >= 4.8
-#
-
-#
-# libsoil needs an OpenGL backend and a toolchain w/ dynamic library
+# librsvg needs a toolchain w/ wchar, threads, C++, gcc >= 4.9
 #
 # BR2_PACKAGE_LIBSVG is not set
 # BR2_PACKAGE_LIBSVG_CAIRO is not set
@@ -1652,32 +1744,36 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 #
 # opencv3 needs a toolchain w/ C++, NPTL, wchar, dynamic library
 #
+
+#
+# opencv4 needs a toolchain w/ C++, NPTL, wchar, dynamic library, gcc >= 4.8
+#
 # BR2_PACKAGE_OPENJPEG is not set
 
 #
-# pango needs a toolchain w/ wchar, threads, C++, gcc >= 4.8
+# pango needs a toolchain w/ wchar, threads, C++, gcc >= 4.9
 #
 
 #
-# pangomm needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# pangomm needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 # BR2_PACKAGE_PIPEWIRE is not set
 # BR2_PACKAGE_PIXMAN is not set
 
 #
-# poppler needs a toolchain w/ wchar, C++, threads, dynamic library, gcc >= 5
+# poppler needs a toolchain w/ wchar, C++, threads, dynamic library, gcc >= 7
 #
 # BR2_PACKAGE_TIFF is not set
 # BR2_PACKAGE_WAYLAND is not set
 BR2_PACKAGE_WEBKITGTK_ARCH_SUPPORTS=y
 
 #
-# webkitgtk needs libgtk3 and a glibc toolchain w/ C++, gcc >= 7, host gcc >= 4.9
+# webkitgtk needs libgtk3 and a toolchain w/ C++, wchar, threads, dynamic library, gcc >= 7, host gcc >= 4.9
 #
 # BR2_PACKAGE_WEBP is not set
 
 #
-# wlroots needs udev, mesa3d w/ EGL and GLES support
+# wlroots needs udev, EGL w/ Wayland backend and OpenGL ES support
 #
 
 #
@@ -1749,9 +1845,13 @@ BR2_PACKAGE_LIBAIO=y
 # BR2_PACKAGE_LIBPHIDGET is not set
 
 #
-# libpri needs a kernel to be built
+# libpri needs a Linux kernel to be built
 #
 # BR2_PACKAGE_LIBQMI is not set
+
+#
+# libqrtr-glib needs a toolchain w/ wchar, threads, headers >= 4.15
+#
 # BR2_PACKAGE_LIBRAW1394 is not set
 # BR2_PACKAGE_LIBRTLSDR is not set
 
@@ -1764,7 +1864,7 @@ BR2_PACKAGE_LIBAIO=y
 # BR2_PACKAGE_LIBSOC is not set
 
 #
-# libss7 needs a kernel to be built
+# libss7 needs a Linux kernel to be built
 #
 # BR2_PACKAGE_LIBUSB is not set
 # BR2_PACKAGE_LIBUSBGX is not set
@@ -1805,12 +1905,6 @@ BR2_PACKAGE_MRAA_ARCH_SUPPORTS=y
 # BR2_PACKAGE_JSZIP is not set
 # BR2_PACKAGE_OPENLAYERS is not set
 # BR2_PACKAGE_POPPERJS is not set
-BR2_PACKAGE_SPIDERMONKEY_ARCH_SUPPORTS=y
-BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
-
-#
-# spidermonkey needs a glibc or musl toolchain with C++, wchar, dynamic library, NPTL, gcc >= 4.9
-#
 # BR2_PACKAGE_VUEJS is not set
 
 #
@@ -1846,7 +1940,7 @@ BR2_PACKAGE_LIBFASTJSON=y
 # BR2_PACKAGE_LIBXML2 is not set
 
 #
-# libxml++ needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# libxml++ needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 # BR2_PACKAGE_LIBXMLRPC is not set
 # BR2_PACKAGE_LIBXSLT is not set
@@ -1862,6 +1956,8 @@ BR2_PACKAGE_LIBFASTJSON=y
 #
 # BR2_PACKAGE_RAPIDXML is not set
 # BR2_PACKAGE_RAPTOR is not set
+# BR2_PACKAGE_SERD is not set
+# BR2_PACKAGE_SORD is not set
 
 #
 # tinyxml needs a toolchain w/ C++
@@ -1876,7 +1972,11 @@ BR2_PACKAGE_LIBFASTJSON=y
 #
 
 #
-# xerces-c++ needs a toolchain w/ C++, wchar
+# xerces-c++ needs a toolchain w/ C++, dynamic library, wchar
+#
+
+#
+# xml-security-c needs a toolchain w/ C++, wchar, dynamic library, threads, gcc >= 4.7
 #
 # BR2_PACKAGE_YAJL is not set
 
@@ -1907,16 +2007,28 @@ BR2_PACKAGE_LIBLOGGING=y
 #
 
 #
+# log4qt needs qt5
+#
+
+#
 # opentracing-cpp needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.8
 #
 
 #
 # spdlog needs a toolchain w/ C++, threads, wchar
 #
+
+#
+# ulog needs a toolchain w/ C++, threads
+#
 # BR2_PACKAGE_ZLOG is not set
 
 #
 # Multimedia
+#
+
+#
+# bento4 support needs a toolchain with C++
 #
 # BR2_PACKAGE_BITSTREAM is not set
 # BR2_PACKAGE_DAV1D is not set
@@ -1927,7 +2039,7 @@ BR2_PACKAGE_LIBLOGGING=y
 # BR2_PACKAGE_LIBAACS is not set
 
 #
-# libass needs a toolchain w/ C++, gcc >= 4.8
+# libass needs a toolchain w/ C++, gcc >= 4.9
 #
 # BR2_PACKAGE_LIBBDPLUS is not set
 # BR2_PACKAGE_LIBBLURAY is not set
@@ -1935,6 +2047,10 @@ BR2_PACKAGE_LIBCAMERA_ARCH_SUPPORTS=y
 
 #
 # libcamera needs a toolchain w/ C++, threads, wchar, dynamic library, gcc >= 7
+#
+
+#
+# libcamera-apps needs a toolchain w/ C++, threads, wchar, dynamic library, gcc >= 7
 #
 # BR2_PACKAGE_LIBDCADEC is not set
 # BR2_PACKAGE_LIBDVBCSA is not set
@@ -1958,6 +2074,7 @@ BR2_PACKAGE_LIBCAMERA_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBMMS is not set
 # BR2_PACKAGE_LIBMPEG2 is not set
 # BR2_PACKAGE_LIBOGG is not set
+# BR2_PACKAGE_LIBOPENAPTX is not set
 BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 
 #
@@ -1994,7 +2111,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 
 #
-# azmq needs a toolchain w/ C++11, wchar and NPTL
+# azmq needs a toolchain w/ C++11, wchar and threads
 #
 
 #
@@ -2009,8 +2126,6 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 # belle-sip needs a toolchain w/ threads, C++, dynamic library, wchar
 #
 # BR2_PACKAGE_C_ARES is not set
-BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
-# BR2_PACKAGE_CANFESTIVAL is not set
 # BR2_PACKAGE_CGIC is not set
 
 #
@@ -2025,6 +2140,7 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 # czmq needs a toolchain w/ C++, threads
 #
 # BR2_PACKAGE_DAQ is not set
+# BR2_PACKAGE_DAQ3 is not set
 # BR2_PACKAGE_DAVICI is not set
 # BR2_PACKAGE_ENET is not set
 
@@ -2038,7 +2154,7 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_GLIB_NETWORKING is not set
 
 #
-# grpc needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.9, host gcc >= 4.9
+# grpc needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.9
 #
 # BR2_PACKAGE_GSSDP is not set
 # BR2_PACKAGE_GUPNP is not set
@@ -2065,6 +2181,7 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBCURL is not set
 # BR2_PACKAGE_LIBDNET is not set
 # BR2_PACKAGE_LIBEXOSIP2 is not set
+# BR2_PACKAGE_LIBEST is not set
 # BR2_PACKAGE_LIBFCGI is not set
 # BR2_PACKAGE_LIBGSASL is not set
 # BR2_PACKAGE_LIBHTP is not set
@@ -2090,7 +2207,7 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBMODBUS is not set
 
 #
-# libmodsecurity needs a toolchain w/ C++, dynamic library, threads
+# libmodsecurity needs a toolchain w/ C++, threads
 #
 # BR2_PACKAGE_LIBNATPMP is not set
 # BR2_PACKAGE_LIBNDP is not set
@@ -2121,6 +2238,7 @@ BR2_PACKAGE_LIBNL=y
 #
 # libpjsip needs a toolchain w/ C++, threads
 #
+# BR2_PACKAGE_LIBPSL is not set
 # BR2_PACKAGE_LIBRELP is not set
 # BR2_PACKAGE_LIBRSYNC is not set
 # BR2_PACKAGE_LIBSHAIRPLAY is not set
@@ -2129,8 +2247,10 @@ BR2_PACKAGE_LIBNL=y
 # BR2_PACKAGE_LIBSOUP is not set
 # BR2_PACKAGE_LIBSRTP is not set
 # BR2_PACKAGE_LIBSTROPHE is not set
+# BR2_PACKAGE_LIBTEAM is not set
 # BR2_PACKAGE_LIBTELNET is not set
 BR2_PACKAGE_LIBTIRPC=y
+# BR2_PACKAGE_LIBTIRPC_GSS is not set
 
 #
 # libtorrent needs a toolchain w/ C++, threads
@@ -2141,6 +2261,10 @@ BR2_PACKAGE_LIBTIRPC=y
 #
 # BR2_PACKAGE_LIBUEV is not set
 # BR2_PACKAGE_LIBUHTTPD is not set
+
+#
+# libuhttpd needs a toolchain w/ gcc >= 4.9
+#
 # BR2_PACKAGE_LIBUPNP is not set
 
 #
@@ -2194,7 +2318,7 @@ BR2_PACKAGE_LIBTIRPC=y
 #
 
 #
-# pistache needs a glibc toolchain w/ C++, gcc >= 4.9, threads, wchar
+# pistache needs a glibc toolchain w/ C++, gcc >= 4.9, threads, wchar, not binutils bug 27597
 #
 # BR2_PACKAGE_QDECODER is not set
 # BR2_PACKAGE_QPID_PROTON is not set
@@ -2208,6 +2332,7 @@ BR2_PACKAGE_LIBTIRPC=y
 # restclient-cpp needs a toolchain w/ C++, gcc >= 4.8
 #
 # BR2_PACKAGE_RTMPDUMP is not set
+# BR2_PACKAGE_SIPROXD is not set
 # BR2_PACKAGE_SLIRP is not set
 
 #
@@ -2246,6 +2371,10 @@ BR2_PACKAGE_LIBTIRPC=y
 
 #
 # Other
+#
+
+#
+# ACE needs a glibc toolchain, dynamic library, C++, gcc >= 4.8
 #
 # BR2_PACKAGE_APR is not set
 # BR2_PACKAGE_APR_UTIL is not set
@@ -2291,7 +2420,6 @@ BR2_PACKAGE_LIBTIRPC=y
 #
 # clang needs a toolchain w/ wchar, threads, C++, gcc >= 4.8, dynamic library
 #
-# BR2_PACKAGE_CLAPACK is not set
 # BR2_PACKAGE_CMOCKA is not set
 
 #
@@ -2330,7 +2458,7 @@ BR2_PACKAGE_LIBTIRPC=y
 #
 
 #
-# glibmm needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# glibmm needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 
 #
@@ -2345,10 +2473,12 @@ BR2_PACKAGE_GOBJECT_INTROSPECTION_ARCH_SUPPORTS=y
 # BR2_PACKAGE_GSL is not set
 
 #
-# gtest needs a toolchain w/ C++, wchar, threads
+# gtest needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
 #
+# BR2_PACKAGE_GUMBO_PARSER is not set
 BR2_PACKAGE_JEMALLOC_ARCH_SUPPORTS=y
 # BR2_PACKAGE_JEMALLOC is not set
+BR2_PACKAGE_LAPACK_ARCH_SUPPORTS=y
 
 #
 # lapack/blas needs a toolchain w/ fortran
@@ -2390,11 +2520,19 @@ BR2_PACKAGE_LIBEASTL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBEV is not set
 # BR2_PACKAGE_LIBEVDEV is not set
 BR2_PACKAGE_LIBEVENT=y
+
+#
+# libexecinfo needs a musl or uclibc toolchain w/ dynamic library
+#
 # BR2_PACKAGE_LIBFFI is not set
+
+#
+# libfutils needs a toolchain w/ C++, threads
+#
 # BR2_PACKAGE_LIBGEE is not set
 
 #
-# libgeos needs a toolchain w/ C++, wchar, not binutils bug 21464, 27597
+# libgeos needs a toolchain w/ C++, wchar, threads not binutils bug 27597
 #
 # BR2_PACKAGE_LIBGLIB2 is not set
 # BR2_PACKAGE_LIBGLOB is not set
@@ -2403,6 +2541,10 @@ BR2_PACKAGE_LIBEVENT=y
 # libical needs a toolchain w/ C++, dynamic library, wchar
 #
 # BR2_PACKAGE_LIBITE is not set
+
+#
+# libks needs a toolchain w/ C++, threads, dynamic library
+#
 
 #
 # liblinear needs a toolchain w/ C++
@@ -2414,6 +2556,14 @@ BR2_PACKAGE_LIBEVENT=y
 # BR2_PACKAGE_LIBNPTH is not set
 BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_LIBNSPR is not set
+
+#
+# libosmium needs a toolchain w/ C++,  wchar, threads, gcc >= 4.7
+#
+
+#
+# libpeas needs python3
+#
 # BR2_PACKAGE_LIBPFM4 is not set
 
 #
@@ -2422,11 +2572,16 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_LIBPTHREAD_STUBS is not set
 # BR2_PACKAGE_LIBPTHSEM is not set
 # BR2_PACKAGE_LIBPWQUALITY is not set
+# BR2_PACKAGE_LIBQB is not set
 BR2_PACKAGE_LIBSECCOMP_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBSECCOMP is not set
 
 #
-# libsigc++ needs a toolchain w/ C++, gcc >= 4.8
+# libshdata needs a toolchain w/ C++, threads
+#
+
+#
+# libsigc++ needs a toolchain w/ C++, gcc >= 7
 #
 BR2_PACKAGE_LIBSIGSEGV_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBSIGSEGV is not set
@@ -2434,6 +2589,7 @@ BR2_PACKAGE_LIBSIGSEGV_ARCH_SUPPORTS=y
 #
 # libspatialindex needs a toolchain w/ C++, gcc >= 4.7
 #
+# BR2_PACKAGE_LIBTALLOC is not set
 # BR2_PACKAGE_LIBTASN1 is not set
 # BR2_PACKAGE_LIBTOMMATH is not set
 # BR2_PACKAGE_LIBTPL is not set
@@ -2442,7 +2598,11 @@ BR2_PACKAGE_LIBSIGSEGV_ARCH_SUPPORTS=y
 BR2_PACKAGE_LIBUNWIND_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBUNWIND is not set
 BR2_PACKAGE_LIBURCU_ARCH_SUPPORTS=y
-# BR2_PACKAGE_LIBURCU is not set
+BR2_PACKAGE_LIBURCU=y
+
+#
+# liburing needs a toolchain w/ gcc >= 4.9, headers >= 5.1
+#
 # BR2_PACKAGE_LIBUV is not set
 # BR2_PACKAGE_LIGHTNING is not set
 # BR2_PACKAGE_LINUX_PAM is not set
@@ -2484,7 +2644,11 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 #
 
 #
-# qhull needs a toolchain w/ C++, dynamic library, gcc >= 4.4
+# protozero needs a toolchain w/ C++,  gcc >= 4.7
+#
+
+#
+# qhull needs a toolchain w/ C++, gcc >= 4.4
 #
 # BR2_PACKAGE_QLIBC is not set
 
@@ -2515,6 +2679,10 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBSEMANAGE is not set
 # BR2_PACKAGE_LIBSEPOL is not set
 # BR2_PACKAGE_SAFECLIB is not set
+
+#
+# softhsm2 needs a toolchain w/ C++, threads, gcc >= 4.8 and dynamic library support
+#
 
 #
 # Text and terminal handling
@@ -2592,7 +2760,7 @@ BR2_PACKAGE_BITCOIN_ARCH_SUPPORTS=y
 # BR2_PACKAGE_COLLECTL is not set
 
 #
-# domoticz needs lua 5.3 and a toolchain w/ C++, gcc >= 4.8, NPTL, wchar, dynamic library
+# domoticz needs lua 5.3 and a toolchain w/ C++, gcc >= 6, NPTL, wchar, dynamic library
 #
 # BR2_PACKAGE_EMPTY is not set
 
@@ -2611,7 +2779,6 @@ BR2_PACKAGE_BITCOIN_ARCH_SUPPORTS=y
 # BR2_PACKAGE_GSETTINGS_DESKTOP_SCHEMAS is not set
 # BR2_PACKAGE_HAVEGED is not set
 # BR2_PACKAGE_LINUX_SYSCALL_SUPPORT is not set
-# BR2_PACKAGE_MCRYPT is not set
 # BR2_PACKAGE_MOBILE_BROADBAND_PROVIDER_INFO is not set
 # BR2_PACKAGE_NETDATA is not set
 
@@ -2622,8 +2789,9 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 # BR2_PACKAGE_QEMU is not set
 
 #
-# qpdf needs a toolchain w/ C++, wchar, gcc >= 4.7
+# qpdf needs a toolchain w/ C++, gcc >= 5
 #
+# BR2_PACKAGE_RTL_433 is not set
 # BR2_PACKAGE_SHARED_MIME_INFO is not set
 
 #
@@ -2633,6 +2801,7 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 # taskd needs a toolchain w/ C++, wchar, dynamic library
 #
+# BR2_PACKAGE_XMRIG is not set
 # BR2_PACKAGE_XUTIL_UTIL_MACROS is not set
 
 #
@@ -2642,6 +2811,7 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 # aircrack-ng needs a toolchain w/ dynamic library, threads, C++
 #
+# BR2_PACKAGE_ALFRED is not set
 # BR2_PACKAGE_AOETOOLS is not set
 # BR2_PACKAGE_APACHE is not set
 # BR2_PACKAGE_ARGUS is not set
@@ -2666,9 +2836,10 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 # BR2_PACKAGE_BIRD is not set
 # BR2_PACKAGE_BLUEZ5_UTILS is not set
 # BR2_PACKAGE_BMON is not set
+# BR2_PACKAGE_BMX7 is not set
 
 #
-# boinc needs a toolchain w/ dynamic library, C++, threads
+# boinc needs a toolchain w/ dynamic library, C++, threads, gcc >= 4.8
 #
 # BR2_PACKAGE_BRCM_PATCHRAM_PLUS is not set
 # BR2_PACKAGE_BRIDGE_UTILS is not set
@@ -2680,6 +2851,10 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 # cannelloni needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.8
 #
 # BR2_PACKAGE_CASYNC is not set
+
+#
+# cfm needs a toolchain w/ threads, kernel headers >= 5.0
+#
 # BR2_PACKAGE_CHRONY is not set
 # BR2_PACKAGE_CIVETWEB is not set
 # BR2_PACKAGE_CONNMAN is not set
@@ -2700,7 +2875,7 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 
 #
-# cups-filters needs a toolchain w/ wchar, C++, threads and dynamic library, gcc >= 4.8
+# cups-filters needs a toolchain w/ wchar, C++, threads and dynamic library, gcc >= 5
 #
 # BR2_PACKAGE_DANTE is not set
 # BR2_PACKAGE_DARKHTTPD is not set
@@ -2730,7 +2905,7 @@ BR2_PACKAGE_DHCPCD=y
 # BR2_PACKAGE_FRR is not set
 
 #
-# gerbera needs a toolchain w/ C++, threads, wchar, gcc >= 8
+# gerbera needs a toolchain w/ C++, dynamic library, threads, wchar, gcc >= 8
 #
 # BR2_PACKAGE_GESFTPSERVER is not set
 
@@ -2796,9 +2971,10 @@ BR2_PACKAGE_IPROUTE2=y
 # BR2_PACKAGE_KEEPALIVED is not set
 
 #
-# kismet needs a toolchain w/ threads, C++
+# kismet needs a toolchain w/ threads, C++, gcc >= 5
 #
 # BR2_PACKAGE_KNOCK is not set
+# BR2_PACKAGE_KSMBD_TOOLS is not set
 # BR2_PACKAGE_LEAFNODE2 is not set
 # BR2_PACKAGE_LFT is not set
 
@@ -2833,14 +3009,17 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 #
 # mongrel2 needs a uClibc or glibc toolchain w/ C++, threads, dynamic library
 #
-# BR2_PACKAGE_MONKEY is not set
 
 #
 # mosh needs a toolchain w/ C++, threads, dynamic library, wchar, gcc >= 4.8
 #
 # BR2_PACKAGE_MOSQUITTO is not set
 # BR2_PACKAGE_MROUTED is not set
-# BR2_PACKAGE_MRP is not set
+
+#
+# mrp needs a toolchain w/ threads, kernel headers >= 5.0
+#
+# BR2_PACKAGE_MSTPD is not set
 # BR2_PACKAGE_MTR is not set
 # BR2_PACKAGE_NBD is not set
 # BR2_PACKAGE_NCFTP is not set
@@ -2931,7 +3110,6 @@ BR2_PACKAGE_RSYNC=y
 # rtorrent needs a toolchain w/ C++, threads, wchar, gcc >= 4.9
 #
 # BR2_PACKAGE_RTPTOOLS is not set
-# BR2_PACKAGE_RYGEL is not set
 # BR2_PACKAGE_S6_DNS is not set
 # BR2_PACKAGE_S6_NETWORKING is not set
 # BR2_PACKAGE_SAMBA4 is not set
@@ -2949,6 +3127,10 @@ BR2_PACKAGE_RSYNC=y
 # BR2_PACKAGE_SMCROUTE is not set
 # BR2_PACKAGE_SNGREP is not set
 # BR2_PACKAGE_SNORT is not set
+
+#
+# snort3 needs a toolchain w/ C++, wchar, threads, dynamic library, gcc >= 4.9
+#
 # BR2_PACKAGE_SOCAT is not set
 # BR2_PACKAGE_SOCKETCAND is not set
 # BR2_PACKAGE_SOFTETHER is not set
@@ -2957,7 +3139,7 @@ BR2_PACKAGE_RSYNC=y
 # BR2_PACKAGE_SPICE_PROTOCOL is not set
 
 #
-# squid needs a toolchain w/ C++, gcc >= 4.8 not affected by bug 64735
+# squid needs a toolchain w/ C++, threads, gcc >= 4.8 not affected by bug 64735
 #
 # BR2_PACKAGE_SSDP_RESPONDER is not set
 # BR2_PACKAGE_SSHGUARD is not set
@@ -2985,13 +3167,14 @@ BR2_PACKAGE_RSYNC=y
 # BR2_PACKAGE_UHTTPD is not set
 # BR2_PACKAGE_ULOGD is not set
 # BR2_PACKAGE_UNBOUND is not set
+# BR2_PACKAGE_UQMI is not set
 # BR2_PACKAGE_UREDIR is not set
 # BR2_PACKAGE_USHARE is not set
 # BR2_PACKAGE_USSP_PUSH is not set
 # BR2_PACKAGE_VDE2 is not set
 
 #
-# vdr needs a glibc toolchain w/ C++, dynamic library, NPTL, wchar, headers >= 3.9
+# vdr needs a toolchain w/ C++, dynamic library, NPTL, wchar, headers >= 3.9
 #
 # BR2_PACKAGE_VNSTAT is not set
 # BR2_PACKAGE_VPNC is not set
@@ -3000,6 +3183,10 @@ BR2_PACKAGE_RSYNC=y
 # BR2_PACKAGE_WAVEMON is not set
 # BR2_PACKAGE_WGET is not set
 # BR2_PACKAGE_WHOIS is not set
+
+#
+# wireguard-linux-compat needs a Linux kernel to be built
+#
 # BR2_PACKAGE_WIREGUARD_TOOLS is not set
 # BR2_PACKAGE_WIRELESS_REGDB is not set
 BR2_PACKAGE_WIRELESS_TOOLS=y
@@ -3007,6 +3194,9 @@ BR2_PACKAGE_WIRELESS_TOOLS=y
 # BR2_PACKAGE_WIRESHARK is not set
 BR2_PACKAGE_WPA_SUPPLICANT=y
 BR2_PACKAGE_WPA_SUPPLICANT_NL80211=y
+# BR2_PACKAGE_WPA_SUPPLICANT_WEXT is not set
+# BR2_PACKAGE_WPA_SUPPLICANT_WIRED is not set
+# BR2_PACKAGE_WPA_SUPPLICANT_IBSS_RSN is not set
 # BR2_PACKAGE_WPA_SUPPLICANT_AP_SUPPORT is not set
 # BR2_PACKAGE_WPA_SUPPLICANT_AUTOSCAN is not set
 # BR2_PACKAGE_WPA_SUPPLICANT_EAP is not set
@@ -3017,6 +3207,7 @@ BR2_PACKAGE_WPA_SUPPLICANT_NL80211=y
 BR2_PACKAGE_WPA_SUPPLICANT_CLI=y
 # BR2_PACKAGE_WPA_SUPPLICANT_WPA_CLIENT_SO is not set
 BR2_PACKAGE_WPA_SUPPLICANT_PASSPHRASE=y
+BR2_PACKAGE_WPA_SUPPLICANT_CTRL_IFACE=y
 # BR2_PACKAGE_WPA_SUPPLICANT_DBUS is not set
 # BR2_PACKAGE_WPAN_TOOLS is not set
 # BR2_PACKAGE_XINETD is not set
@@ -3025,6 +3216,7 @@ BR2_PACKAGE_WPA_SUPPLICANT_PASSPHRASE=y
 #
 # xtables-addons needs a Linux kernel to be built
 #
+# BR2_PACKAGE_ZABBIX is not set
 
 #
 # znc needs a toolchain w/ C++, dynamic library, gcc >= 4.8, threads
@@ -3078,7 +3270,11 @@ BR2_PACKAGE_WPA_SUPPLICANT_PASSPHRASE=y
 # -------------------------------------------------------
 #
 # BR2_PACKAGE_OPKG is not set
-# BR2_PACKAGE_RPM is not set
+# BR2_PACKAGE_OPKG_UTILS is not set
+
+#
+# rpm needs a toolchain w/ dynamic library, threads and lua >= 5.3
+#
 
 #
 # Real-Time
@@ -3117,6 +3313,7 @@ BR2_PACKAGE_XENOMAI_COBALT_ARCH_SUPPORTS=y
 # Shells
 #
 BR2_PACKAGE_BASH=y
+# BR2_PACKAGE_BASH_LOADABLE_EXAMPLES is not set
 # BR2_PACKAGE_DASH is not set
 # BR2_PACKAGE_MKSH is not set
 # BR2_PACKAGE_ZSH is not set
@@ -3124,6 +3321,7 @@ BR2_PACKAGE_BASH=y
 #
 # Utilities
 #
+# BR2_PACKAGE_APG is not set
 # BR2_PACKAGE_AT is not set
 # BR2_PACKAGE_BASH_COMPLETION is not set
 # BR2_PACKAGE_CCRYPT is not set
@@ -3171,6 +3369,7 @@ BR2_PACKAGE_AUDIT_ARCH_SUPPORTS=y
 #
 # circus needs Python 3 and a toolchain w/ C++, threads
 #
+# BR2_PACKAGE_CONTAINERD is not set
 # BR2_PACKAGE_COREUTILS is not set
 # BR2_PACKAGE_CPULOAD is not set
 # BR2_PACKAGE_DAEMON is not set
@@ -3182,17 +3381,14 @@ BR2_PACKAGE_AUDIT_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_DEBIANUTILS is not set
 # BR2_PACKAGE_DOCKER_CLI is not set
-
-#
-# docker-compose needs a toolchain w/ C++, wchar, threads, dynamic library
-#
-# BR2_PACKAGE_DOCKER_CONTAINERD is not set
+# BR2_PACKAGE_DOCKER_COMPOSE is not set
 # BR2_PACKAGE_DOCKER_ENGINE is not set
 # BR2_PACKAGE_DOCKER_PROXY is not set
 # BR2_PACKAGE_EARLYOOM is not set
 # BR2_PACKAGE_EFIBOOTMGR is not set
 BR2_PACKAGE_EFIVAR_ARCH_SUPPORTS=y
 # BR2_PACKAGE_EFIVAR is not set
+# BR2_PACKAGE_EMBIGGEN_DISK is not set
 
 #
 # emlog needs a Linux kernel to be built
@@ -3204,7 +3400,7 @@ BR2_PACKAGE_EFIVAR_ARCH_SUPPORTS=y
 # BR2_PACKAGE_IBM_SW_TPM2 is not set
 
 #
-# iotop depends on python or python3
+# iotop depends on python3
 #
 # BR2_PACKAGE_IPRUTILS is not set
 # BR2_PACKAGE_IRQBALANCE is not set
@@ -3217,11 +3413,14 @@ BR2_PACKAGE_KMOD=y
 # BR2_PACKAGE_KMOD_TOOLS is not set
 # BR2_PACKAGE_KVMTOOL is not set
 # BR2_PACKAGE_LIBOSTREE is not set
+BR2_PACKAGE_LIBVIRT_ARCH_SUPPORTS=y
+# BR2_PACKAGE_LIBVIRT is not set
 # BR2_PACKAGE_LXC is not set
 BR2_PACKAGE_MAKEDUMPFILE_ARCH_SUPPORTS=y
 # BR2_PACKAGE_MAKEDUMPFILE is not set
 # BR2_PACKAGE_MENDER is not set
 # BR2_PACKAGE_MFOC is not set
+# BR2_PACKAGE_MOBY_BUILDKIT is not set
 # BR2_PACKAGE_MONIT is not set
 # BR2_PACKAGE_MULTIPATH_TOOLS is not set
 # BR2_PACKAGE_NCDU is not set
@@ -3239,10 +3438,7 @@ BR2_PACKAGE_MAKEDUMPFILE_ARCH_SUPPORTS=y
 #
 # pamtester depends on linux-pam
 #
-
-#
-# polkit needs a glibc or musl toolchain with C++, wchar, dynamic library, NPTL, gcc >= 4.9
-#
+# BR2_PACKAGE_POLKIT is not set
 # BR2_PACKAGE_PROCPS_NG is not set
 # BR2_PACKAGE_PROCRANK_LINUX is not set
 # BR2_PACKAGE_PSMISC is not set
@@ -3261,8 +3457,13 @@ BR2_PACKAGE_RSYSLOG=y
 # BR2_PACKAGE_SCRYPT is not set
 
 #
+# sdbus-c++ needs systemd and a toolchain w/ C++, gcc >= 7
+#
+
+#
 # sdbusplus needs systemd and a toolchain w/ C++, gcc >= 7
 #
+# BR2_PACKAGE_SEATD is not set
 # BR2_PACKAGE_SMACK is not set
 # BR2_PACKAGE_START_STOP_DAEMON is not set
 
@@ -3277,7 +3478,7 @@ BR2_PACKAGE_SYSTEMD_BOOTCHART_ARCH_SUPPORTS=y
 # BR2_PACKAGE_TAR is not set
 
 #
-# thermald needs a toolchain w/ C++, wchar, threads
+# thermald needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
 #
 # BR2_PACKAGE_TPM_TOOLS is not set
 # BR2_PACKAGE_TPM2_ABRMD is not set
@@ -3347,6 +3548,7 @@ BR2_PACKAGE_UTIL_LINUX_PARTX=y
 # BR2_PACKAGE_UTIL_LINUX_WRITE is not set
 # BR2_PACKAGE_UTIL_LINUX_ZRAMCTL is not set
 # BR2_PACKAGE_WATCHDOG is not set
+# BR2_PACKAGE_WATCHDOGD is not set
 # BR2_PACKAGE_XDG_DBUS_PROXY is not set
 BR2_PACKAGE_XVISOR_ARCH_SUPPORTS=y
 # BR2_PACKAGE_XVISOR is not set
@@ -3354,6 +3556,7 @@ BR2_PACKAGE_XVISOR_ARCH_SUPPORTS=y
 #
 # Text editors and viewers
 #
+# BR2_PACKAGE_BAT is not set
 # BR2_PACKAGE_ED is not set
 # BR2_PACKAGE_JOE is not set
 # BR2_PACKAGE_LESS is not set
@@ -3381,9 +3584,10 @@ BR2_PACKAGE_XVISOR_ARCH_SUPPORTS=y
 #
 
 #
-# iso image needs a Linux kernel and either grub2 i386-pc or isolinux to be built
+# iso image needs a Linux kernel and either grub2 or isolinux to be built
 #
 # BR2_TARGET_ROOTFS_JFFS2 is not set
+# BR2_TARGET_ROOTFS_OCI is not set
 # BR2_TARGET_ROOTFS_ROMFS is not set
 # BR2_TARGET_ROOTFS_SQUASHFS is not set
 BR2_TARGET_ROOTFS_TAR=y
@@ -3403,6 +3607,8 @@ BR2_TARGET_ROOTFS_TAR_OPTIONS=""
 # Bootloaders
 #
 # BR2_TARGET_BAREBOX is not set
+BR2_TARGET_EDK2_ARCH_SUPPORTS=y
+# BR2_TARGET_EDK2 is not set
 BR2_TARGET_GRUB2_ARCH_SUPPORTS=y
 # BR2_TARGET_GRUB2 is not set
 # BR2_TARGET_GUMMIBOOT is not set
@@ -3418,6 +3624,7 @@ BR2_TARGET_GRUB2_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_ANDROID_TOOLS is not set
 # BR2_PACKAGE_HOST_ASN1C is not set
 # BR2_PACKAGE_HOST_BABELTRACE2 is not set
+# BR2_PACKAGE_HOST_BMAP_TOOLS is not set
 # BR2_PACKAGE_HOST_BTRFS_PROGS is not set
 # BR2_PACKAGE_HOST_CHECKPOLICY is not set
 # BR2_PACKAGE_HOST_CHECKSEC is not set
@@ -3425,6 +3632,7 @@ BR2_TARGET_GRUB2_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_CRAMFS is not set
 # BR2_PACKAGE_HOST_CRYPTSETUP is not set
 # BR2_PACKAGE_HOST_DBUS_PYTHON is not set
+# BR2_PACKAGE_HOST_DELVE is not set
 # BR2_PACKAGE_HOST_DFU_UTIL is not set
 # BR2_PACKAGE_HOST_DOS2UNIX is not set
 # BR2_PACKAGE_HOST_DOSFSTOOLS is not set
@@ -3439,6 +3647,7 @@ BR2_PACKAGE_HOST_EUDEV=y
 # BR2_PACKAGE_HOST_F2FS_TOOLS is not set
 # BR2_PACKAGE_HOST_FAKETIME is not set
 # BR2_PACKAGE_HOST_FATCAT is not set
+# BR2_PACKAGE_HOST_FIRMWARE_UTILS is not set
 # BR2_PACKAGE_HOST_FWUP is not set
 # BR2_PACKAGE_HOST_GENEXT2FS is not set
 # BR2_PACKAGE_HOST_GENIMAGE is not set
@@ -3464,16 +3673,18 @@ BR2_PACKAGE_HOST_GOOGLE_BREAKPAD_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_MKPASSWD is not set
 # BR2_PACKAGE_HOST_MTD is not set
 # BR2_PACKAGE_HOST_MTOOLS is not set
+# BR2_PACKAGE_HOST_NODEJS is not set
 # BR2_PACKAGE_HOST_ODB is not set
 # BR2_PACKAGE_HOST_OPENOCD is not set
 # BR2_PACKAGE_HOST_OPKG_UTILS is not set
+# BR2_PACKAGE_HOST_PAHOLE is not set
 # BR2_PACKAGE_HOST_PARTED is not set
 BR2_PACKAGE_HOST_PATCHELF=y
 # BR2_PACKAGE_HOST_PIGZ is not set
 # BR2_PACKAGE_HOST_PKGCONF is not set
 # BR2_PACKAGE_HOST_PWGEN is not set
-# BR2_PACKAGE_HOST_PYTHON is not set
 # BR2_PACKAGE_HOST_PYTHON_CYTHON is not set
+# BR2_PACKAGE_HOST_PYTHON_GREENLET is not set
 # BR2_PACKAGE_HOST_PYTHON_LXML is not set
 # BR2_PACKAGE_HOST_PYTHON_SIX is not set
 # BR2_PACKAGE_HOST_PYTHON_XLRD is not set
@@ -3484,7 +3695,9 @@ BR2_PACKAGE_HOST_QEMU_USER_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_QEMU is not set
 # BR2_PACKAGE_HOST_QORIQ_RCW is not set
 # BR2_PACKAGE_HOST_RAUC is not set
+# BR2_PACKAGE_HOST_RISCV_ISA_SIM is not set
 BR2_PACKAGE_HOST_RUSTC_ARCH_SUPPORTS=y
+BR2_PACKAGE_HOST_RUSTC_TARGET_TIER1_PLATFORMS=y
 BR2_PACKAGE_HOST_RUSTC_TARGET_ARCH_SUPPORTS=y
 BR2_PACKAGE_HOST_RUSTC_ARCH="x86_64"
 # BR2_PACKAGE_HOST_RUSTC is not set
@@ -3492,6 +3705,7 @@ BR2_PACKAGE_PROVIDES_HOST_RUSTC="host-rust-bin"
 # BR2_PACKAGE_HOST_SAM_BA is not set
 # BR2_PACKAGE_HOST_SDBUSPLUS is not set
 # BR2_PACKAGE_HOST_SENTRY_CLI is not set
+# BR2_PACKAGE_HOST_SLOCI_IMAGE is not set
 # BR2_PACKAGE_HOST_SQUASHFS is not set
 # BR2_PACKAGE_HOST_SWIG is not set
 # BR2_PACKAGE_HOST_UBOOT_TOOLS is not set
@@ -3507,12 +3721,111 @@ BR2_PACKAGE_PROVIDES_HOST_RUSTC="host-rust-bin"
 #
 
 #
-# Legacy options removed in 2021.02
+# Legacy options removed in 2022.02
 #
+# BR2_PACKAGE_WESTON_DEFAULT_FBDEV is not set
+# BR2_PACKAGE_WESTON_FBDEV is not set
+# BR2_PACKAGE_PYTHON_PYCLI is not set
+# BR2_PACKAGE_LINUX_TOOLS_BPFTOOL is not set
+# BR2_TARGET_UBOOT_NEEDS_PYTHON2 is not set
+# BR2_PACKAGE_GST1_PLUGINS_BAD_PLUGIN_LIBMMS is not set
+# BR2_PACKAGE_PYTHON_FUNCTOOLS32 is not set
+# BR2_PACKAGE_PYTHON_ENUM34 is not set
+# BR2_PACKAGE_PYTHON_ENUM is not set
+# BR2_PACKAGE_PYTHON_DIALOG is not set
+# BR2_PACKAGE_PYTHON_CONFIGOBJ is not set
+# BR2_PACKAGE_PYTHON_YIELDFROM is not set
+# BR2_PACKAGE_PYTHON_TYPING is not set
+# BR2_PACKAGE_PYTHON_SUBPROCESS32 is not set
+# BR2_PACKAGE_PYTHON_SINGLEDISPATCH is not set
+# BR2_PACKAGE_PYTHON_PYRO is not set
+# BR2_PACKAGE_PYTHON_PYPCAP is not set
+# BR2_PACKAGE_PYTHON_PATHLIB2 is not set
+# BR2_PACKAGE_PYTHON_PAM is not set
+# BR2_PACKAGE_PYTHON_NFC is not set
+# BR2_PACKAGE_PYTHON_MAD is not set
+# BR2_PACKAGE_PYTHON_IPADDRESS is not set
+# BR2_PACKAGE_PYTHON_IPADDR is not set
+# BR2_PACKAGE_PYTHON_ID3 is not set
+# BR2_PACKAGE_PYTHON_FUTURES is not set
+# BR2_PACKAGE_PYTHON_BACKPORTS_SSL_MATCH_HOSTNAME is not set
+# BR2_PACKAGE_PYTHON_BACKPORTS_SHUTIL_GET_TERMINAL_SIZE is not set
+# BR2_PACKAGE_PYTHON_BACKPORTS_ABC is not set
+# BR2_PACKAGE_PYTHON is not set
+# BR2_TARGET_UBOOT_ZYNQ_IMAGE is not set
+# BR2_PACKAGE_HOST_GDB_PYTHON is not set
+# BR2_PACKAGE_GSTREAMER1_MM is not set
+# BR2_KERNEL_HEADERS_5_14 is not set
+# BR2_PACKAGE_PYTHON_BACKPORTS_FUNCTOOLS_LRU_CACHE is not set
+# BR2_PACKAGE_CIVETWEB_WITH_LUA is not set
+# BR2_PACKAGE_SUNXI_MALI_MAINLINE_DRIVER is not set
+# BR2_PACKAGE_SUNXI_MALI_MAINLINE is not set
+# BR2_PACKAGE_SUNXI_MALI_MAINLINE_R6P2 is not set
+# BR2_PACKAGE_SUNXI_MALI_MAINLINE_R8P1 is not set
+# BR2_PACKAGE_QT5WEBKIT_EXAMPLES is not set
+# BR2_TOOLCHAIN_EXTERNAL_BOOTLIN_RISCV64_GLIBC_BLEEDING_EDGE is not set
+# BR2_TOOLCHAIN_EXTERNAL_BOOTLIN_RISCV64_MUSL_BLEEDING_EDGE is not set
+# BR2_PACKAGE_IPUTILS_TFTPD is not set
+# BR2_PACKAGE_IPUTILS_TRACEROUTE6 is not set
+# BR2_PACKAGE_LIBMEDIAART_BACKEND_NONE is not set
+# BR2_PACKAGE_MPD_UPNP is not set
+
+#
+# Legacy options removed in 2021.11
+#
+# BR2_OPENJDK_VERSION_LTS is not set
+# BR2_OPENJDK_VERSION_LATEST is not set
+# BR2_PACKAGE_MPD_TIDAL is not set
+# BR2_PACKAGE_MROUTED_RSRR is not set
+# BR2_BINUTILS_VERSION_CSKY is not set
+# BR2_GCC_VERSION_CSKY is not set
+# BR2_PACKAGE_CANFESTIVAL is not set
+# BR2_PACKAGE_NMAP_NDIFF is not set
+# BR2_GDB_VERSION_8_3 is not set
+# BR2_PACKAGE_PYTHON_MELD3 is not set
+# BR2_PACKAGE_STRONGSWAN_EAP is not set
+# BR2_PACKAGE_GNURADIO_PAGER is not set
+# BR2_KERNEL_HEADERS_5_11 is not set
+# BR2_KERNEL_HEADERS_5_12 is not set
+# BR2_KERNEL_HEADERS_5_13 is not set
+
+#
+# Legacy options removed in 2021.08
+#
+BR2_TARGET_GRUB2_BUILTIN_MODULES=""
+BR2_TARGET_GRUB2_BUILTIN_CONFIG=""
+# BR2_PACKAGE_LIBMCRYPT is not set
+# BR2_PACKAGE_MCRYPT is not set
+# BR2_PACKAGE_PHP_EXT_MCRYPT is not set
+# BR2_BINUTILS_VERSION_2_34_X is not set
+# BR2_PACKAGE_LIBSOIL is not set
+# BR2_PACKAGE_CLAPACK is not set
+# BR2_PACKAGE_SPIDERMONKEY is not set
+# BR2_PACKAGE_KODI_LIBVA is not set
+# BR2_PACKAGE_PYTHON_COHERENCE is not set
+# BR2_PACKAGE_PHP_EXT_XMLRPC is not set
+# BR2_GCC_VERSION_8_X is not set
+
+#
+# Legacy options removed in 2021.05
+#
+# BR2_PACKAGE_UDISKS_LVM2 is not set
+# BR2_PACKAGE_LVM2_APP_LIBRARY is not set
+# BR2_PACKAGE_LVM2_LVMETAD is not set
+# BR2_PACKAGE_MONKEY is not set
+# BR2_PACKAGE_DOCKER_CONTAINERD is not set
+# BR2_PACKAGE_IOSTAT is not set
 # BR2_PACKAGE_SCONESERVER_HTTP_SCONESITE_IMAGE is not set
 # BR2_PACKAGE_XSERVER_XORG_SERVER_KDRIVE_EVDEV is not set
 # BR2_PACKAGE_XSERVER_XORG_SERVER_KDRIVE_KBD is not set
 # BR2_PACKAGE_XSERVER_XORG_SERVER_KDRIVE_MOUSE is not set
+# BR2_PACKAGE_MESA3D_OSMESA_CLASSIC is not set
+# BR2_PACKAGE_MESA3D_DRI_DRIVER_SWRAST is not set
+# BR2_PACKAGE_KODI_SCREENSAVER_CRYSTALMORPH is not set
+
+#
+# Legacy options removed in 2021.02
+#
 # BR2_PACKAGE_MPD_AUDIOFILE is not set
 # BR2_PACKAGE_AUDIOFILE is not set
 # BR2_BINUTILS_VERSION_2_33_X is not set
@@ -3530,6 +3843,9 @@ BR2_PACKAGE_PROVIDES_HOST_RUSTC="host-rust-bin"
 #
 # Legacy options removed in 2020.11
 #
+# BR2_PACKAGE_GPSD_FIXED_PORT_SPEED is not set
+# BR2_PACKAGE_GPSD_RECONFIGURE is not set
+# BR2_PACKAGE_GPSD_CONTROLSEND is not set
 # BR2_PACKAGE_OPENCV is not set
 # BR2_PACKAGE_LIBCROCO is not set
 # BR2_PACKAGE_BELLAGIO is not set

--- a/patches/dhcpcd-disable-privsep.patch
+++ b/patches/dhcpcd-disable-privsep.patch
@@ -1,0 +1,12 @@
+diff --git a/package/dhcpcd/Config.in b/package/dhcpcd/Config.in
+index 3ebacb3..203d203 100644
+--- a/package/dhcpcd/Config.in
++++ b/package/dhcpcd/Config.in
+@@ -13,7 +13,6 @@ if BR2_PACKAGE_DHCPCD
+ 
+ config BR2_PACKAGE_DHCPCD_ENABLE_PRIVSEP
+ 	bool
+-	default y
+ 	depends on BR2_USE_MMU
+ 	# Audit headers were only added in recent kernels for some arches
+ 	depends on !(BR2_arceb || BR2_arcle) || \

--- a/scripts/build-busybox
+++ b/scripts/build-busybox
@@ -32,6 +32,12 @@ busybox_install()
     tar xf ${ARTIFACTS}/${buildroot} -C ${DIR} --strip-components=1
     cd ${DIR}
 
+    echo "Enabling custom patches"
+    for p in `find ../../patches -name "*.patch"`; do
+        echo "patching $p"
+        patch -p1 -i $p
+    done
+
     cp $conf .config
     if [ -n "$bbconf" ]; then
         cp $bbconf package/busybox/

--- a/scripts/release
+++ b/scripts/release
@@ -9,6 +9,8 @@ mv build.log dist/build_${ARCH}.log
 echo "#!/bin/sh"> dist/publish.sh
 if [ "${ARCH}" == "amd64" ]; then
     echo "github-release release --user burmilla --repo os-base --tag "${RELEASE_VERSION}" --pre-release" >> dist/publish.sh
+    echo "echo Waiting 30 seconds after release creation to make sure that GitHub is ready for uploads" >> dist/publish.sh
+    echo "sleep 30s" >> dist/publish.sh
 fi
 echo "for f in \$(ls ./dist/artifacts) ; do" >> dist/publish.sh
 echo "   github-release upload  --user burmilla --repo os-base --tag "${RELEASE_VERSION}" --file ./dist/artifacts/\${f} --name \${f}" >> dist/publish.sh


### PR DESCRIPTION
Have:

- Upgraded to buildroot 2022.02.3, 
- Upgraded 5.10.x kernel version to 5.10.129.

Fix for burmilla/os/issues/132 has been cherry-picked and is assumed to be independent of the kernel version.