### PR TITLE
Update Buildroot 2022.02.3 config

### DIFF
--- a/config/amd64/buildroot-config
+++ b/config/amd64/buildroot-config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Buildroot 2022.02 Configuration
+# Buildroot 2022.02.3 Configuration
 #
 BR2_HAVE_DOT_CONFIG=y
 BR2_HOST_GCC_AT_LEAST_4_9=y
@@ -71,7 +71,7 @@ BR2_x86_nocona=y
 # BR2_x86_broadwell is not set
 # BR2_x86_skylake is not set
 # BR2_x86_atom is not set
-# BR2_x86_bonnel is not set
+# BR2_x86_bonnell is not set
 # BR2_x86_silvermont is not set
 # BR2_x86_goldmont is not set
 # BR2_x86_goldmont_plus is not set
@@ -194,16 +194,16 @@ BR2_TOOLCHAIN_BUILDROOT_LIBC="glibc"
 #
 # BR2_KERNEL_HEADERS_4_4 is not set
 # BR2_KERNEL_HEADERS_4_9 is not set
-BR2_KERNEL_HEADERS_4_14=y
+# BR2_KERNEL_HEADERS_4_14 is not set
 # BR2_KERNEL_HEADERS_4_19 is not set
 # BR2_KERNEL_HEADERS_5_4 is not set
-# BR2_KERNEL_HEADERS_5_10 is not set
+BR2_KERNEL_HEADERS_5_10=y
 # BR2_KERNEL_HEADERS_5_15 is not set
 # BR2_KERNEL_HEADERS_5_16 is not set
 # BR2_KERNEL_HEADERS_VERSION is not set
 # BR2_KERNEL_HEADERS_CUSTOM_TARBALL is not set
 # BR2_KERNEL_HEADERS_CUSTOM_GIT is not set
-BR2_DEFAULT_KERNEL_HEADERS="5.10.129"
+BR2_DEFAULT_KERNEL_HEADERS="5.10.120"
 BR2_PACKAGE_LINUX_HEADERS=y
 
 #
@@ -217,11 +217,11 @@ BR2_PACKAGE_GLIBC=y
 # Binutils Options
 #
 BR2_PACKAGE_HOST_BINUTILS_SUPPORTS_CFI=y
-BR2_BINUTILS_VERSION_2_32_X=y
+# BR2_BINUTILS_VERSION_2_32_X is not set
 # BR2_BINUTILS_VERSION_2_35_X is not set
 # BR2_BINUTILS_VERSION_2_36_X is not set
-# BR2_BINUTILS_VERSION_2_37_X is not set
-BR2_BINUTILS_VERSION="2.32"
+BR2_BINUTILS_VERSION_2_37_X=y
+BR2_BINUTILS_VERSION="2.37"
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS=""
 
 #
@@ -302,7 +302,24 @@ BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_11=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_12=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_13=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_14=y
-BR2_TOOLCHAIN_HEADERS_AT_LEAST="4.14"
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_15=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_16=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_17=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_18=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_19=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_4_20=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_0=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_1=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_2=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_3=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_4=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_5=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_6=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_7=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_8=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_9=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_10=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST="5.10"
 BR2_TOOLCHAIN_GCC_AT_LEAST_4_3=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_4_4=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_4_5=y
@@ -417,7 +434,10 @@ BR2_PACKAGE_FFMPEG_ARCH_SUPPORTS=y
 # BR2_PACKAGE_FLAC is not set
 # BR2_PACKAGE_FLITE is not set
 # BR2_PACKAGE_FLUID_SOUNDFONT is not set
-# BR2_PACKAGE_FLUIDSYNTH is not set
+
+#
+# fluidsynth needs a toolchain w/ threads, wchar, dynamic library, C++
+#
 # BR2_PACKAGE_GMRENDER_RESURRECT is not set
 # BR2_PACKAGE_GSTREAMER1 is not set
 # BR2_PACKAGE_JACK1 is not set
@@ -544,6 +564,7 @@ BR2_PACKAGE_XZ=y
 #
 # bonnie++ needs a toolchain w/ C++
 #
+BR2_PACKAGE_BPFTOOL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_BPFTOOL is not set
 # BR2_PACKAGE_CACHE_CALIBRATOR is not set
 
@@ -1277,7 +1298,7 @@ BR2_PACKAGE_HOST_MONO_ARCH_SUPPORTS=y
 BR2_PACKAGE_MONO_ARCH_SUPPORTS=y
 
 #
-# mono needs a toolchain w/ C++, threads, dynamic library
+# mono needs a toolchain w/ C++, NPTL, dynamic library
 #
 BR2_PACKAGE_NODEJS_ARCH_SUPPORTS=y
 
@@ -1625,7 +1646,7 @@ BR2_PACKAGE_LIBSYSFS=y
 # BR2_PACKAGE_GIFLIB is not set
 
 #
-# granite needs libgtk3 and a toolchain w/ wchar, threads
+# granite needs libgtk3 and a toolchain w/ wchar, threads, gcc >= 4.9
 #
 
 #
@@ -1641,7 +1662,10 @@ BR2_PACKAGE_LIBSYSFS=y
 #
 # BR2_PACKAGE_IJS is not set
 # BR2_PACKAGE_IMLIB2 is not set
-# BR2_PACKAGE_INTEL_GMMLIB is not set
+
+#
+# intel-gmmlib needs a toolchain w/ dynamic library, C++
+#
 
 #
 # intel-mediadriver needs a toolchain w/ dynamic library, C++, NPTL
@@ -1848,10 +1872,7 @@ BR2_PACKAGE_LIBAIO=y
 # libpri needs a Linux kernel to be built
 #
 # BR2_PACKAGE_LIBQMI is not set
-
-#
-# libqrtr-glib needs a toolchain w/ wchar, threads, headers >= 4.15
-#
+# BR2_PACKAGE_LIBQRTR_GLIB is not set
 # BR2_PACKAGE_LIBRAW1394 is not set
 # BR2_PACKAGE_LIBRTLSDR is not set
 
@@ -1968,7 +1989,7 @@ BR2_PACKAGE_LIBFASTJSON=y
 #
 
 #
-# valijson needs a toolchain w/ C++, threads, wchar  support
+# valijson needs a toolchain w/ C++
 #
 
 #
@@ -2321,7 +2342,10 @@ BR2_PACKAGE_LIBTIRPC=y
 # pistache needs a glibc toolchain w/ C++, gcc >= 4.9, threads, wchar, not binutils bug 27597
 #
 # BR2_PACKAGE_QDECODER is not set
-# BR2_PACKAGE_QPID_PROTON is not set
+
+#
+# qpid-proton needs a toolchain w/ C++, dynamic library, threads
+#
 # BR2_PACKAGE_RABBITMQ_C is not set
 
 #
@@ -2543,7 +2567,7 @@ BR2_PACKAGE_LIBEVENT=y
 # BR2_PACKAGE_LIBITE is not set
 
 #
-# libks needs a toolchain w/ C++, threads, dynamic library
+# libks needs a toolchain w/ C++, NPTL, dynamic library
 #
 
 #
@@ -2599,10 +2623,7 @@ BR2_PACKAGE_LIBUNWIND_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBUNWIND is not set
 BR2_PACKAGE_LIBURCU_ARCH_SUPPORTS=y
 BR2_PACKAGE_LIBURCU=y
-
-#
-# liburing needs a toolchain w/ gcc >= 4.9, headers >= 5.1
-#
+# BR2_PACKAGE_LIBURING is not set
 # BR2_PACKAGE_LIBUV is not set
 # BR2_PACKAGE_LIGHTNING is not set
 # BR2_PACKAGE_LINUX_PAM is not set
@@ -2801,7 +2822,10 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 # taskd needs a toolchain w/ C++, wchar, dynamic library
 #
-# BR2_PACKAGE_XMRIG is not set
+
+#
+# xmrig needs a glibc or musl toolchain w/ NPTL, dynamic library, C++
+#
 # BR2_PACKAGE_XUTIL_UTIL_MACROS is not set
 
 #
@@ -2851,10 +2875,7 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 # cannelloni needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.8
 #
 # BR2_PACKAGE_CASYNC is not set
-
-#
-# cfm needs a toolchain w/ threads, kernel headers >= 5.0
-#
+# BR2_PACKAGE_CFM is not set
 # BR2_PACKAGE_CHRONY is not set
 # BR2_PACKAGE_CIVETWEB is not set
 # BR2_PACKAGE_CONNMAN is not set
@@ -3015,10 +3036,7 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 #
 # BR2_PACKAGE_MOSQUITTO is not set
 # BR2_PACKAGE_MROUTED is not set
-
-#
-# mrp needs a toolchain w/ threads, kernel headers >= 5.0
-#
+# BR2_PACKAGE_MRP is not set
 # BR2_PACKAGE_MSTPD is not set
 # BR2_PACKAGE_MTR is not set
 # BR2_PACKAGE_NBD is not set
@@ -3135,7 +3153,10 @@ BR2_PACKAGE_RSYNC=y
 # BR2_PACKAGE_SOCKETCAND is not set
 # BR2_PACKAGE_SOFTETHER is not set
 # BR2_PACKAGE_SPAWN_FCGI is not set
-# BR2_PACKAGE_SPICE is not set
+
+#
+# spice server needs a toolchain w/ wchar, threads, C++
+#
 # BR2_PACKAGE_SPICE_PROTOCOL is not set
 
 #
@@ -3191,7 +3212,10 @@ BR2_PACKAGE_RSYNC=y
 # BR2_PACKAGE_WIRELESS_REGDB is not set
 BR2_PACKAGE_WIRELESS_TOOLS=y
 # BR2_PACKAGE_WIRELESS_TOOLS_LIB is not set
-# BR2_PACKAGE_WIRESHARK is not set
+
+#
+# wireshark needs a toolchain w/ wchar, threads, dynamic library, C++
+#
 BR2_PACKAGE_WPA_SUPPLICANT=y
 BR2_PACKAGE_WPA_SUPPLICANT_NL80211=y
 # BR2_PACKAGE_WPA_SUPPLICANT_WEXT is not set
@@ -3612,6 +3636,7 @@ BR2_TARGET_EDK2_ARCH_SUPPORTS=y
 BR2_TARGET_GRUB2_ARCH_SUPPORTS=y
 # BR2_TARGET_GRUB2 is not set
 # BR2_TARGET_GUMMIBOOT is not set
+BR2_PACKAGE_SHIM_ARCH_SUPPORTS=y
 # BR2_TARGET_SHIM is not set
 # BR2_TARGET_SYSLINUX is not set
 # BR2_TARGET_UBOOT is not set
@@ -3723,6 +3748,9 @@ BR2_PACKAGE_PROVIDES_HOST_RUSTC="host-rust-bin"
 #
 # Legacy options removed in 2022.02
 #
+# BR2_sh2a is not set
+BR2_TARGET_ROOTFS_OCI_ENTRYPOINT_ARGS=""
+# BR2_PACKAGE_LIBCURL_LIBNSS is not set
 # BR2_PACKAGE_WESTON_DEFAULT_FBDEV is not set
 # BR2_PACKAGE_WESTON_FBDEV is not set
 # BR2_PACKAGE_PYTHON_PYCLI is not set


### PR DESCRIPTION
I've now updated this correctly and double checked there are no prompts at build time. Including changes discussed at #1 (upgrade binutils)

Only question is, do I need to update BR2_DEFAULT_KERNEL_HEADERS to be the latest (that os-kernel is running) eg. 5.10.129, or is it OK to remain at 5.10.120? I would just edit the Buildroot config directly.